### PR TITLE
Flip the card back when inputing the name

### DIFF
--- a/src/CreditCard.svelte
+++ b/src/CreditCard.svelte
@@ -17,6 +17,7 @@
 
   // Previous Values
   let prevCVC = "";
+  let prevName = "";
 
   // Derived Values
 
@@ -24,6 +25,13 @@
     if (prevCVC !== cvc) {
       focused = "cvc";
       prevCVC = cvc;
+    }
+  }
+
+  $: {
+    if (prevName !== name) {
+      focused = "name";
+      prevName = name;
     }
   }
 


### PR DESCRIPTION
# Summary / Description
This PR addresses a fix for the flipping feature which does not flips the card back when inputting the name right after the CVC. The same behavior works fine for the others fields.

Fixes #8
